### PR TITLE
ppx_tools compatibility update

### DIFF
--- a/packages/ppx_tools/ppx_tools.5.0+4.02.3/url
+++ b/packages/ppx_tools/ppx_tools.5.0+4.02.3/url
@@ -1,2 +1,2 @@
-archive: "https://github.com/kayceesrk/ppx_tools/archive/v4.02.3-effects.tar.gz"
-checksum: "94b1b58ae78d195ed77965a4d6e47ae2"
+archive: "https://github.com/dhil/ppx_tools/archive/v4.02.3-multicore.tar.gz"
+checksum: "d83114ff9a055c16f02bf9b2b4c3a498"


### PR DESCRIPTION
This PR provides a version of ppx_tools v4.02.3 that is compatible with Multicore OCaml with the default handlers patch.

Accept this PR once ocamllabs/ocaml-multicore#123 has been merged.