### PR TITLE
Patches for ppx-tools on multicore

### DIFF
--- a/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.10+multicore-1/opam
+++ b/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.10+multicore-1/opam
@@ -1,0 +1,19 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/let-def/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/let-def/ocaml-migrate-parsetree/issues"
+dev-repo: "git://github.com/let-def/ocaml-migrate-parsetree.git"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "jbuilder" {build & >= "1.0+beta7"}
+  "ocaml-migrate-parsetree"
+  "ocamlbuild"
+]
+available: ocaml-version >= "4.06.1"

--- a/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.10+multicore-1/url
+++ b/packages/ocaml-migrate-parsetree-ocamlbuild/ocaml-migrate-parsetree-ocamlbuild.1.0.10+multicore-1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/jhwoodyatt/ocaml-migrate-parsetree/archive/v1.0.10+multicore-1.zip"
+checksum: "e19e84e0f2b05e6a4c2823b0a585f906"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10+multicore-1/descr
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10+multicore-1/descr
@@ -1,0 +1,4 @@
+Convert OCaml parsetrees between different versions 
+
+This library converts parsetrees, outcometree and ast mappers between different OCaml versions.
+High-level functions help making PPX rewriters independent of a compiler version.

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10+multicore-1/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10+multicore-1/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+tags: [ "syntax" "org:ocamllabs" ]
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "result"
+  "ocamlfind" {build}
+  "jbuilder" {build & >= "1.0+beta18.1"}
+]
+available: ocaml-version >= "4.06.1"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10+multicore-1/url
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0.10+multicore-1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/jhwoodyatt/ocaml-migrate-parsetree/archive/v1.0.10+multicore-1.zip"
+checksum: "e19e84e0f2b05e6a4c2823b0a585f906"

--- a/packages/ppx_tools/ppx_tools.5.1+4.06.0+multicore-1/descr
+++ b/packages/ppx_tools/ppx_tools.5.1+4.06.0+multicore-1/descr
@@ -1,0 +1,1 @@
+Tools for authors of ppx rewriters and other syntactic tools

--- a/packages/ppx_tools/ppx_tools.5.1+4.06.0+multicore-1/opam
+++ b/packages/ppx_tools/ppx_tools.5.1+4.06.0+multicore-1/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+name: "ppx_tools"
+maintainer: "alain.frisch@lexifi.com"
+authors: [ "Alain Frisch <alain.frisch@lexifi.com>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+dev-repo: "git://github.com/ocaml-ppx/ppx_tools.git"
+tags: [ "syntax" ]
+build: [[make "all"]]
+install: [[make "install"]]
+remove: [["ocamlfind" "remove" "ppx_tools"]]
+depends: [
+  "ocamlfind" {>= "1.5.0"}
+]
+available: ocaml-version >= "4.06.0"

--- a/packages/ppx_tools/ppx_tools.5.1+4.06.0+multicore-1/url
+++ b/packages/ppx_tools/ppx_tools.5.1+4.06.0+multicore-1/url
@@ -1,0 +1,2 @@
+archive: "https://github.com/jhwoodyatt/ppx_tools/archive/5.1+4.06.0+multicore-1.zip"
+checksum: "4f036f24a88d86c79d89e00538cc371d"


### PR DESCRIPTION
Add the following packages containing patches for OCaml 4.06 +multicore.
- ocaml-migrate-parsetree 1.0.10+multicore-1
- ocaml-migrate-parsetree-ocamlbuild 1.0.10+multicore-1
- ppx_tools 5.1+4.06.0+multicore-1