### PR TITLE
New instructions for adding remote under opam.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,8 @@ OPAM repo for OCaml multicore development
 ### OPAM 2.0
 
 ```
-opam repository add multicore https://github.com/ocamllabs/multicore-opam.git --all
 opam update
-opam switch create 4.06.1+multicore --empty
-opam switch 4.06.1+multicore
-opam install ocaml-variants.4.06.1+multicore
+opam switch create 4.06.1+multicore --repositories=multicore=git+https://github.com/ocamllabs/multicore-opam.git,default
 ```
 
 ### OPAM 1.2
@@ -19,4 +16,25 @@ opam install ocaml-variants.4.06.1+multicore
 opam remote add multicore https://github.com/ocamllabs/multicore-opam.git
 opam update
 opam switch 4.06.1+multicore
+```
+
+## Installing dune
+
+There is a version of dune.1.9.1 that the Multicore OCaml compiler can build.
+You can install it by:
+
+```
+opam install dune.1.9.1
+```
+
+If you need dune > 2.0, you need to follow a different procedure. With recent
+dune versions, you can also use the dune binary built under other compiler
+versions. For this, you can copy the dune binary under some compiler switch to
+the bin directory of the multicore switch (try `echo $(opam config var bin)` for
+the location of the bin directory).
+
+## Installing domainslib
+
+```
+opam install dune.1.9.1 domainslib
 ```


### PR DESCRIPTION
Modifies instructions based on recommendations from #15. Reorders the remotes in the switch create command so that multicore versions of packages are preferred. 