### PR TITLE
Install Dune using ocaml-secondary-compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,11 @@ opam update
 opam switch create 4.10.0+multicore --repositories=multicore=git+https://github.com/ocamllabs/multicore-opam.git,default
 ```
 
-## Installing dune
-
-There is a version of dune.1.9.1 that the Multicore OCaml compiler can build.
-You can install it by:
+You'll be using Dune, so it's worth instead running:
 
 ```
-opam install dune.1.9.1
+opam switch create 4.10.0+multicore --packages=ocaml-variants.4.10.0+multicore,ocaml-secondary-compiler --repositories=multicore=git+https://github.com/ocamllabs/multicore-opam.git,default
 ```
-
-If you need dune > 2.0, you need to follow a different procedure. With recent
-dune versions, you can also use the dune binary built under other compiler
-versions. For this, you can copy the dune binary under some compiler switch to
-the bin directory of the multicore switch (try `echo $(opam config var bin)` for
-the location of the bin directory).
 
 ## Installing domainslib
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ opam update
 opam switch create 4.06.1+multicore --repositories=multicore=git+https://github.com/ocamllabs/multicore-opam.git,default
 ```
 
-### OPAM 1.2
-
-```
-opam remote add multicore https://github.com/ocamllabs/multicore-opam.git
-opam update
-opam switch 4.06.1+multicore
-```
-
 ## Installing dune
 
 There is a version of dune.1.9.1 that the Multicore OCaml compiler can build.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OPAM repo for OCaml multicore development
 
 ```
 opam update
-opam switch create 4.06.1+multicore --repositories=multicore=git+https://github.com/ocamllabs/multicore-opam.git,default
+opam switch create 4.10.0+multicore --repositories=multicore=git+https://github.com/ocamllabs/multicore-opam.git,default
 ```
 
 ## Installing dune

--- a/packages/dune/dune.2.5.1/0001-Use-secondary-compiler-for-multicore.patch
+++ b/packages/dune/dune.2.5.1/0001-Use-secondary-compiler-for-multicore.patch
@@ -1,0 +1,28 @@
+From 92b06981d8ac1a14dc87d8829a51b2aa36810038 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Fri, 29 May 2020 07:02:15 +0100
+Subject: [PATCH] Use secondary compiler for multicore
+
+---
+ bootstrap.ml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bootstrap.ml b/bootstrap.ml
+index 242487d1..b85b808d 100644
+--- a/bootstrap.ml
++++ b/bootstrap.ml
+@@ -65,9 +65,9 @@ let read_file fn =
+   s
+ 
+ let () =
+-  let v = Scanf.sscanf Sys.ocaml_version "%d.%d" (fun a b -> (a, b)) in
++  let v, p = Scanf.sscanf Sys.ocaml_version "%d.%d%s@+%s" (fun a b c d -> (a, b), p) in
+   let compiler, which =
+-    if v >= min_supported_natively then
++    if v >= min_supported_natively && p <> "multicore" then
+       ("ocamlc", None)
+     else
+       let compiler = "ocamlfind -toolchain secondary ocamlc" in
+-- 
+2.17.1
+

--- a/packages/dune/dune.2.5.1/files/0001-Use-secondary-compiler-for-multicore.patch
+++ b/packages/dune/dune.2.5.1/files/0001-Use-secondary-compiler-for-multicore.patch
@@ -1,0 +1,28 @@
+From 7441d4cf95f3cfce844c606c2914af8e5b687340 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Fri, 29 May 2020 07:35:35 +0100
+Subject: [PATCH] Use secondary compiler for multicore
+
+---
+ bootstrap.ml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bootstrap.ml b/bootstrap.ml
+index 242487d1..835e49ed 100644
+--- a/bootstrap.ml
++++ b/bootstrap.ml
+@@ -65,9 +65,9 @@ let read_file fn =
+   s
+ 
+ let () =
+-  let v = Scanf.sscanf Sys.ocaml_version "%d.%d" (fun a b -> (a, b)) in
++  let v, p = Scanf.sscanf Sys.ocaml_version "%d.%d%s@+%s" (fun a b c d -> (a, b), d) in
+   let compiler, which =
+-    if v >= min_supported_natively then
++    if v >= min_supported_natively && p <> "multicore" then
+       ("ocamlc", None)
+     else
+       let compiler = "ocamlfind -toolchain secondary ocamlc" in
+-- 
+2.17.1
+

--- a/packages/dune/dune.2.5.1/opam
+++ b/packages/dune/dune.2.5.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  "ocaml"
+  "ocamlfind-secondary"
+  "base-unix"
+  "base-threads"
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.5.1/dune-2.5.1.tbz"
+  checksum: [
+    "sha256=8f77d3a87f208e0d7cccaa1c48c4bb1bb87d62d07c3f25e9b8ba298e028ce52b"
+    "sha512=f209f12ced10c1abf8782bdb0143f4cec77795f7174d2cc75130afb1e01550b01f2f77b9e3ec4888efdad83d2f9878d179b39126f824f4e522f3ef4da34bf27e"
+  ]
+}
+extra-files: ["0001-Use-secondary-compiler-for-multicore.patch" "md5=111932739a07e8a0648bcc908253cfa7"]
+patches: "0001-Use-secondary-compiler-for-multicore.patch"

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.10.0/files/0001-Correct-implementation-of-disable-stdlib-manpages.patch
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.10.0/files/0001-Correct-implementation-of-disable-stdlib-manpages.patch
@@ -1,0 +1,55 @@
+From 86616abe604a6f1d3f25b670ac6a3202a7d7720f Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Wed, 26 Feb 2020 15:07:17 +0000
+Subject: [PATCH] Correct implementation of --disable-stdlib-manpages
+
+---
+ Makefile          | 4 ++--
+ ocamldoc/Makefile | 8 +-------
+ 2 files changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 802196d1e..8a3b33d95 100644
+--- a/Makefile
++++ b/Makefile
+@@ -423,7 +423,7 @@ opt.opt: checknative
+ 	$(MAKE) otherlibrariesopt
+ 	$(MAKE) ocamllex.opt ocamltoolsopt ocamltoolsopt.opt $(OCAMLDOC_OPT) \
+ 	  ocamltest.opt
+-ifneq "$(WITH_OCAMLDOC)" ""
++ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
+ 	$(MAKE) manpages
+ endif
+ 
+@@ -453,7 +453,7 @@ coreboot:
+ all: coreall
+ 	$(MAKE) ocaml
+ 	$(MAKE) otherlibraries $(WITH_DEBUGGER) $(WITH_OCAMLDOC) ocamltest
+-ifneq "$(WITH_OCAMLDOC)" ""
++ifeq "$(WITH_OCAMLDOC)-$(STDLIB_MANPAGES)" "ocamldoc-true"
+ 	$(MAKE) manpages
+ endif
+ 
+diff --git a/ocamldoc/Makefile b/ocamldoc/Makefile
+index 4a6e0fc6c..c828e6c9c 100644
+--- a/ocamldoc/Makefile
++++ b/ocamldoc/Makefile
+@@ -185,14 +185,8 @@ LIBCMOFILES = $(CMOFILES)
+ LIBCMXFILES = $(LIBCMOFILES:.cmo=.cmx)
+ LIBCMIFILES = $(LIBCMOFILES:.cmo=.cmi)
+ 
+-ifeq "$(STDLIB_MANPAGES)" "true"
+-DOCS_TARGET = manpages
+-else
+-DOCS_TARGET =
+-endif
+-
+ .PHONY: all
+-all: lib exe generators $(DOCS_TARGET)
++all: lib exe generators
+ 
+ .PHONY: exe
+ exe: $(OCAMLDOC)
+-- 
+2.17.1
+

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.10.0/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.10.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.10.0 Secondary Switch Compiler"
+maintainer: "platform@lists.ocaml.org"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+dev-repo: "git://github.com/ocaml/ocaml"
+build: [
+  [
+    "./configure"
+      "--prefix=%{_:share}%"
+      "--libdir=%{_:share}%/lib"
+      "--disable-debugger"
+      "--disable-installing-bytecode-programs"
+      "--disable-debug-runtime"
+      "--disable-instrumented-runtime"
+      "CC=cc" {os = "openbsd" | os = "freebsd" | os = "macos"}
+      "ASPP=cc -c" {os = "openbsd" | os = "freebsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%" "world.opt"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.10.0.tar.gz"
+  checksum: "sha256=58bae0f0a79daf86ec755a173e593fef4ef588f15c6185993af88ceb9722bc39"
+}
+extra-files: [
+  ["0001-Correct-implementation-of-disable-stdlib-manpages.patch" "md5=93116cb79dd3f966bbe1cd2e858c2346"]
+]
+patches: [
+  "0001-Correct-implementation-of-disable-stdlib-manpages.patch"
+]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1 & os != "cygwin"}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
+]
+description: "Installs an additional compiler to the opam switch in
+%{_:share}%/ocaml-secondary-compiler which can be accessed using
+`ocamlfind -toolchain secondary`."
+flags: compiler


### PR DESCRIPTION
Dune has a shim to allow installation on older versions of OCaml which can be utilised quite successfully for multicore to allow installation. The patch to upstream's opam file is small and just needs to be mapped on to each Dune release.

`ocaml-secondary-compiler` is updated to 4.10.0 partly because it looks better to install two identical versions and partly because it would require more patching to Dune's bootstrap otherwise. This package will actually go in the other direction back to opam-repository at some point. The only multicore-specific patches to it were the addition of `flags: compiler` and the deletion of the `depends` field.

Let the spice flow (more easily).