### PR TITLE
Ensure ocaml-variants.4.10.0+multicore doesn't install with -Werror

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.10.0+multicore/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+multicore/opam
@@ -11,7 +11,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
-  ["./configure" "--prefix" "%{prefix}%" "--enable-debug-runtime"]
+  ["./configure" "--prefix" "%{prefix}%" "--enable-debug-runtime" "--disable-warn-error"]
   ["%{make}%" "world.opt"]
 ]
 install: ["%{make}%" "install"]


### PR DESCRIPTION
Do not merge until https://github.com/ocaml-multicore/ocaml-multicore/pull/347 is merged (and possibly ocaml/ocaml#9625 as well), although `configure` should just ignore an option it doesn't recognise.