### PR TITLE
update dune to 2.6.0

### DIFF
--- a/packages/dune/dune.2.6.0/files/0001-Use-secondary-compiler-for-multicore.patch
+++ b/packages/dune/dune.2.6.0/files/0001-Use-secondary-compiler-for-multicore.patch
@@ -1,0 +1,28 @@
+From 7441d4cf95f3cfce844c606c2914af8e5b687340 Mon Sep 17 00:00:00 2001
+From: David Allsopp <david.allsopp@metastack.com>
+Date: Fri, 29 May 2020 07:35:35 +0100
+Subject: [PATCH] Use secondary compiler for multicore
+
+---
+ bootstrap.ml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bootstrap.ml b/bootstrap.ml
+index 242487d1..835e49ed 100644
+--- a/bootstrap.ml
++++ b/bootstrap.ml
+@@ -65,9 +65,9 @@ let read_file fn =
+   s
+ 
+ let () =
+-  let v = Scanf.sscanf Sys.ocaml_version "%d.%d" (fun a b -> (a, b)) in
++  let v, p = Scanf.sscanf Sys.ocaml_version "%d.%d%s@+%s" (fun a b c d -> (a, b), d) in
+   let compiler, which =
+-    if v >= min_supported_natively then
++    if v >= min_supported_natively && p <> "multicore" then
+       ("ocamlc", None)
+     else
+       let compiler = "ocamlfind -toolchain secondary ocamlc" in
+-- 
+2.17.1
+

--- a/packages/dune/dune.2.6.0/opam
+++ b/packages/dune/dune.2.6.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "1.3.0"}
+  "dune-release" {< "1.3.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  "ocaml"
+  "ocamlfind-secondary"
+  "base-unix"
+  "base-threads"
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/2.6.0/dune-2.6.0.tbz"
+  checksum: [
+    "sha256=12c9d849fbc5f202f99e9f8ed13fdff7de85ae9c5206cb1b821763dcd1916fc3"
+    "sha512=de808537e471ef5a4ca49f68bfaf99d36441b5d30bc66712467a636e7bf69ea825e30286d882dac4e18a36c3eae45a80c3407d86255484c76570f771d84ce8b5"
+  ]
+}
+patches: "0001-Use-secondary-compiler-for-multicore.patch"
+extra-files: ["0001-Use-secondary-compiler-for-multicore.patch" "md5=111932739a07e8a0648bcc908253cfa7"]


### PR DESCRIPTION
adds opam file for dune 2.6.0
This uses the same patch file used for the dune 2.5.1 package in the multicore repo