### PR TITLE
Use -j%{jobs}% for multicore variant builds

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+no-effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+no-effect-syntax/opam
@@ -12,7 +12,8 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix" "%{prefix}%" "--enable-debug-runtime" "--disable-warn-error"]
-  ["%{make}%" "world.opt"]
+  ["%{make}%" "-j%{jobs}%" "world"]
+  ["%{make}%" "-j%{jobs}%" "world.opt"]
 ]
 install: ["%{make}%" "install"]
 url {

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+multicore/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+multicore/opam
@@ -12,7 +12,8 @@ flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["./configure" "--prefix" "%{prefix}%" "--enable-debug-runtime" "--disable-warn-error"]
-  ["%{make}%" "world.opt"]
+  ["%{make}%" "-j%{jobs}%" "world"]
+  ["%{make}%" "-j%{jobs}%" "world.opt"]
 ]
 install: ["%{make}%" "install"]
 url {


### PR DESCRIPTION
This PR uses `-j%{jobs}%` to speed up opam installs of ocaml-multicore on multicore hosts. 
(Copies the style used here: https://github.com/ocaml/opam-repository/blob/master/packages/ocaml-variants/ocaml-variants.4.10.0%2Brc1/opam)