### PR TITLE
Addition of domainslib 0.2.2 release

### DIFF
--- a/packages/domainslib/domainslib.0.2.2/findlib
+++ b/packages/domainslib/domainslib.0.2.2/findlib
@@ -1,0 +1,1 @@
+domainslib

--- a/packages/domainslib/domainslib.0.2.2/opam
+++ b/packages/domainslib/domainslib.0.2.2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://kayceesrk.github.io/domainslib/doc"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+tags: []
+depends: [
+  "ocamlfind" {build}
+  "dune" {build}
+]
+depopts: []
+build: [
+  "dune" "build" "-p" name
+]
+url {
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.2.2.tar.gz"
+  checksum: "md5=2f4b669c429db2650e64508f23ee7478"
+}
+
+


### PR DESCRIPTION
This PR adds the [domainslib 0.2.2](https://github.com/ocaml-multicore/domainslib/releases/tag/0.2.2) release