### PR TITLE
add ocamlfind-secondary dependency to dune.2.7.1

### DIFF
--- a/packages/dune/dune.2.7.1/opam
+++ b/packages/dune/dune.2.7.1/opam
@@ -41,11 +41,10 @@ build: [
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]
 depends: [
-  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
-  # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
-    "base-unix"
-    "base-threads"
+  "ocaml"
+  "ocamlfind-secondary"
+  "base-unix"
+  "base-threads"
 ]
 url {
   src: "https://github.com/ocaml/dune/releases/download/2.7.1/dune-2.7.1.tbz"


### PR DESCRIPTION
`opam install dune` on a fresh multicore switch was showing this error:

```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] The compilation of dune failed at "/home/sudha/.opam/opam-init/hooks/sandbox.sh build ocaml bootstrap.ml -j 3".

#=== ERROR while compiling dune.2.7.1 =========================================#
# context     2.0.5 | linux/x86_64 |  | git+https://github.com/ocamllabs/multicore-opam.git
# path        ~/.opam/nes/.opam-switch/build/dune.2.7.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build ocaml bootstrap.ml -j 3
# exit-code   2
# env-file    ~/.opam/log/dune-20728-d0f245.env
# output-file ~/.opam/log/dune-20728-d0f245.out
### output ###
# ocamlfind -toolchain secondary ocamlc 2>.duneboot.ocamlfind-output
# sh: 1: ocamlfind: not found
# 
# The ocamlfind's secondary toolchain does not seem to be correctly
# installed.
# Dune requires OCaml 4.08 or later to compile.
# Please either upgrade your compile or configure a secondary OCaml compiler
# (in opam, this can be done by installing the ocamlfind-secondary package).
```

This patch add `ocamlfind-secondary` dependency to dune 2.7.1, which hopefully fixes this error.