### PR TITLE
Added .drone.yml for CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,18 @@
+kind: pipeline
+name: 4.10.0+multicore-opam
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: 4.10.0+multicore-opam
+  image: ocurrent/opam:ubuntu-18.04-ocaml-4.10
+  commands:
+  - opam update
+  - opam switch create 4.10.0+multicore --packages=ocaml-variants.4.10.0+multicore,ocaml-secondary-compiler --repositories=multicore=git+https://github.com/ocamllabs/multicore-opam.git,default
+  - eval $(opam env)
+  - opam --version
+  - opam switch
+  - opam list
+  - opam install dune.2.6.2 domainslib

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,4 +15,4 @@ steps:
   - opam --version
   - opam switch
   - opam list
-  - opam install dune.2.6.2 domainslib
+  - opam install dune domainslib


### PR DESCRIPTION
The PR adds a .drone.yml that launches a Docker container running Ubuntu 18.04 with OCaml 4.10 for the CI, and executes the necessary steps to setup Multicore OCaml.
Reference: https://github.com/ocaml-multicore/multicore-opam/issues/34.