### PR TITLE
Add early support for ocaml-multicore in core_kernel

### DIFF
--- a/packages/core_kernel/core_kernel.v0.14.1+multicore/opam
+++ b/packages/core_kernel/core_kernel.v0.14.1+multicore/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_kernel"
+bug-reports: "https://github.com/janestreet/core_kernel/issues"
+dev-repo: "git+https://github.com/janestreet/core_kernel.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_kernel/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "base"                {>= "v0.14" & < "v0.15"}
+  "base_bigstring"      {>= "v0.14" & < "v0.15"}
+  "base_quickcheck"     {>= "v0.14" & < "v0.15"}
+  "bin_prot"            {>= "v0.14" & < "v0.15"}
+  "fieldslib"           {>= "v0.14" & < "v0.15"}
+  "jane-street-headers" {>= "v0.14" & < "v0.15"}
+  "jst-config"          {>= "v0.14" & < "v0.15"}
+  "ppx_assert"          {>= "v0.14" & < "v0.15"}
+  "ppx_base"            {>= "v0.14" & < "v0.15"}
+  "ppx_hash"            {>= "v0.14" & < "v0.15"}
+  "ppx_inline_test"     {>= "v0.14" & < "v0.15"}
+  "ppx_jane"            {>= "v0.14" & < "v0.15"}
+  "ppx_sexp_conv"       {>= "v0.14" & < "v0.15"}
+  "ppx_sexp_message"    {>= "v0.14" & < "v0.15"}
+  "sexplib"             {>= "v0.14" & < "v0.15"}
+  "splittable_random"   {>= "v0.14" & < "v0.15"}
+  "stdio"               {>= "v0.14" & < "v0.15"}
+  "time_now"            {>= "v0.14" & < "v0.15"}
+  "typerep"             {>= "v0.14" & < "v0.15"}
+  "variantslib"         {>= "v0.14" & < "v0.15"}
+  "dune"                {>= "2.0.0"}
+]
+synopsis: "Industrial strength alternative to OCaml's standard library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+Core_kernel is the system-independent part of Core.
+"
+url {
+  src: "https://github.com/kit-ty-kate/core_kernel/archive/multicore.tar.gz"
+}


### PR DESCRIPTION
for the moment this branch just use placeholder values in place of the missing `caml_stat_*` values. See https://github.com/ocaml-multicore/ocaml-multicore/issues/448