### PR TITLE
Add opam files to allow installing on musl-based environments

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+musl+no-effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+musl+no-effect-syntax/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.10.0, with support for multicore on musl libc"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.10.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev" "libexecinfo-dev"] {os-distribution = "alpine"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix" "%{prefix}%" "--enable-debug-runtime" "--disable-warn-error"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc" {os-distribution != "alpine"}
+    "CFLAGS=-Os"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
+    "--enable-debug-runtime"
+    "--disable-warn-error"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  ["%{make}%" "-j%{jobs}%" "world"]
+  ["%{make}%" "-j%{jobs}%" "world.opt"]
+]
+install: ["%{make}%" "install"]
+url {
+  src: "https://github.com/ocamllabs/ocaml-multicore/archive/no-effect-syntax.tar.gz"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+musl+static+no-effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+musl+static+no-effect-syntax/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.10.0, with support for multicore on musl libc"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.10.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev" "libexecinfo-static"] {os-distribution = "alpine"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix" "%{prefix}%" "--enable-debug-runtime" "--disable-warn-error"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc" {os-distribution != "alpine"}
+    "CFLAGS=-Os"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
+    "LIBS=-static"
+    "--enable-debug-runtime"
+    "--disable-warn-error"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  ["%{make}%" "-j%{jobs}%" "world"]
+  ["%{make}%" "-j%{jobs}%" "world.opt"]
+]
+install: ["%{make}%" "install"]
+url {
+  src: "https://github.com/ocamllabs/ocaml-multicore/archive/no-effect-syntax.tar.gz"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+musl+static/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.10.0, with support for multicore on musl libc"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.10.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev" "libexecinfo-static"] {os-distribution = "alpine"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix" "%{prefix}%" "--enable-debug-runtime" "--disable-warn-error"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc" {os-distribution != "alpine"}
+    "CFLAGS=-Os"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
+    "LIBS=-static"
+    "--enable-debug-runtime"
+    "--disable-warn-error"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  ["%{make}%" "-j%{jobs}%" "world"]
+  ["%{make}%" "-j%{jobs}%" "world.opt"]
+]
+install: ["%{make}%" "install"]
+url {
+  src: "https://github.com/ocamllabs/ocaml-multicore/archive/parallel_minor_gc.tar.gz"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+available: !(os = "macos" & arch = "arm64")

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+multicore+musl/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.10.0, with support for multicore on musl libc"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.10.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+]
+depexts: [
+  ["musl-tools"] {os-family = "debian"}
+  ["musl"] {os-distribution = "arch"}
+  ["musl-dev" "libexecinfo-dev"] {os-distribution = "alpine"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  ["./configure" "--prefix" "%{prefix}%" "--enable-debug-runtime" "--disable-warn-error"]
+    {os != "openbsd" & os != "freebsd" & os != "macos" & os != "linux"}
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "CC=musl-gcc" {os-distribution != "alpine"}
+    "CFLAGS=-Os"
+    "ASPP=musl-gcc -c" {os-distribution != "alpine"}
+    "--enable-debug-runtime"
+    "--disable-warn-error"
+  ] {os = "openbsd" | os = "freebsd" | os = "macos" | os = "linux"}
+  ["%{make}%" "-j%{jobs}%" "world"]
+  ["%{make}%" "-j%{jobs}%" "world.opt"]
+]
+install: ["%{make}%" "install"]
+url {
+  src: "https://github.com/ocamllabs/ocaml-multicore/archive/parallel_minor_gc.tar.gz"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/ocaml/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+available: !(os = "macos" & arch = "arm64")


### PR DESCRIPTION
See: ocaml-multicore/ocaml-multicore#473

With these, musl users should be able to install ocaml multicore inside fresh environments without issues.
Files are adopted from the mainline opam repo.