### PR TITLE
add base-domains and base-effects packages

### DIFF
--- a/packages/base-domains/base-domains.base/opam
+++ b/packages/base-domains/base-domains.base/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml-multicore/multicore-opam/issues"
+description: """
+Domains-based parallelism distributed with the Multicore OCaml compiler"
+"""
+depends: [
+  "ocaml" {>="4.12.0"}
+  "ocaml-variants" {="4.12.0+domains+effects" | ="4.12.0+domains"}
+]

--- a/packages/base-effects/base-effects.base/opam
+++ b/packages/base-effects/base-effects.base/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml-multicore/multicore-opam/issues"
+description: """
+Effects-based variant distributed with the Multicore OCaml compiler"
+"""
+depends: [
+ "ocaml" {>= "4.12.0"}
+ "ocaml-variants" {="4.12.0+domains+effects"}
+]

--- a/packages/core_kernel/core_kernel.v0.14.1+multicore/opam
+++ b/packages/core_kernel/core_kernel.v0.14.1+multicore/opam
@@ -11,6 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08"}
+  "base-domains"
   "base"                {>= "v0.14" & < "v0.15"}
   "base_bigstring"      {>= "v0.14" & < "v0.15"}
   "base_quickcheck"     {>= "v0.14" & < "v0.15"}

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0+effect-syntax/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.1.0+effect-syntax/opam
@@ -16,6 +16,7 @@ build: [
 depends: [
   "dune" {>= "1.11"}
   "ocaml" {>= "4.02.3" & < "4.13"}
+  "base-effects"
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+domains+effects/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+domains+effects/opam
@@ -6,6 +6,8 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+  "base-domains" {post}
+  "base-effects" {post}
   "ocaml-option-nnp"
 ]
 conflict-class: "ocaml-core-compiler"
@@ -44,7 +46,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocamllabs/ocaml-multicore/archive/4.12+domains+effects.tar.gz"
+  src: "git+https://github.com/ocaml-multicore/ocaml-multicore.git#4.12+domains+effects"
 }
 conflicts: [
   "ocaml-options-vanilla"   # This is not vanilla OCaml!

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+domains/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+domains/opam
@@ -6,6 +6,7 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+  "base-domains" {post}
   "ocaml-option-nnp"
 ]
 conflict-class: "ocaml-core-compiler"
@@ -44,7 +45,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocamllabs/ocaml-multicore/archive/4.12+domains.tar.gz"
+  src: "git+https://github.com/ocaml-multicore/ocaml-multicore.git#4.12+domains"
 }
 conflicts: [
   "ocaml-options-vanilla"   # This is not vanilla OCaml!


### PR DESCRIPTION
These can be depended on by effects-only or domains-only packages
here to avoid being selected with the wrong compilers.

Fixes #52