### PR TITLE
Add 0.3.0 release of domainslib

### DIFF
--- a/packages/domainslib/domainslib.0.3.0/findlib
+++ b/packages/domainslib/domainslib.0.3.0/findlib
@@ -1,0 +1,1 @@
+domainslib

--- a/packages/domainslib/domainslib.0.3.0/opam
+++ b/packages/domainslib/domainslib.0.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://kayceesrk.github.io/domainslib/doc"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+tags: []
+depends: [
+  "ocamlfind" {build}
+  "dune" {build}
+  "base-domains"
+]
+depopts: []
+build: [
+  "dune" "build" "-p" name
+]
+url {
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.3.0.tar.gz"
+  checksum: "md5=19ac2e92298b82a406bcb231a00bb3a4"
+}
+
+


### PR DESCRIPTION
This PR adds [release 0.3.0 of domainslib](https://github.com/ocaml-multicore/domainslib/releases/tag/0.3.0)